### PR TITLE
Correct the usage of integer types

### DIFF
--- a/src/bytecode/parser.rs
+++ b/src/bytecode/parser.rs
@@ -67,7 +67,7 @@ fn parse_segment(header: &'static str) -> impl for<'a> Fn(Span<'a>) -> Result<'a
                         separated_pair(take_usize(10), sp, take_usize(10)),
                         newline,
                     ),
-                    many0(terminated(take_u32(10), newline)),
+                    many0(terminated(map(take_u32(10), |i| i as i32), newline)),
                 ))
             ),
             |((start, _end), content)| Segment {

--- a/src/bytecode/program.rs
+++ b/src/bytecode/program.rs
@@ -4,7 +4,7 @@ use super::parser::{parse_bytecode_file, ParseError};
 #[derive(Debug, Clone, Default)]
 pub struct Segment {
     pub start: usize,
-    pub content: Vec<u32>,
+    pub content: Vec<i32>,
 }
 
 #[derive(Debug, Clone)]
@@ -19,7 +19,7 @@ impl Program {
         parse_bytecode_file(nom_locate::LocatedSpan::new(bytecode))
     }
 
-    pub fn to_words(&self) -> Vec<u32> {
+    pub fn to_words(&self) -> Vec<i32> {
         let size = std::cmp::max(
             self.code.start + self.code.content.len(),
             self.data.start + self.data.content.len());

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -108,12 +108,12 @@ impl CompileTarget for Program {
     ) -> Self::Location {
         let (abs_addr, rel_addr) = match segment {
             SegmentType::Text => {
-                self.code.content.push(word as u32);
+                self.code.content.push(word);
                 self.data.start += 1;
                 (self.code.content.len() - 1, self.code.content.len() - 1)
             },
             SegmentType::Data => {
-                self.data.content.push(word as u32);
+                self.data.content.push(word);
                 (self.code.content.len() + self.data.content.len() - 1, self.data.content.len() - 1)
             },
         };
@@ -125,8 +125,8 @@ impl CompileTarget for Program {
 
     fn set_word(&mut self, (segment, addr): &Self::Location, value: i32) {
         match segment {
-            SegmentType::Text => self.code.content[*addr] = value as u32,
-            SegmentType::Data => self.data.content[*addr] = value as u32,
+            SegmentType::Text => self.code.content[*addr] = value,
+            SegmentType::Data => self.data.content[*addr] = value,
         }
     }
 
@@ -364,7 +364,7 @@ MAIN 	LOAD 	R1, X
     }
 
     let ins = prog.code.content.iter()
-        .map(|word| Instruction::try_from(*word).unwrap())
+        .map(|word| Instruction::try_from(*word as u32).unwrap())
         .collect::<Vec<_>>();
 
     println!("{:?}", ins);


### PR DESCRIPTION
Previously the code base contained mixed use of `i32`, `u32` and `u16` without really regard to whether it was the correct type for representing the data.