### PR TITLE
Introduce an event system

### DIFF
--- a/src/emulator.rs
+++ b/src/emulator.rs
@@ -404,11 +404,18 @@ impl<'e,'i,M,IO> InstructionEmulationContext<'e, 'i, M, IO>
             },
             OpCode::Out => {
                 let output = self.first_operand();
-                let device = self.second_operand()?;
+                let device = self.second_operand()? as u16;
+
                 debug!(self.logger, "writing '{}' to device {}", output, device;
                        "output" => output,
                        "device" => device);
-                self.emulator.io.output(device as u16, output);
+
+                self.emulator.io.output(device, output);
+
+                self.dispatch(Event::Output {
+                    device: device,
+                    data: output,
+                });
             },
 
             OpCode::Compare => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -34,6 +34,15 @@ pub enum Event {
         /// The new value of the register.
         data: i32,
     },
+
+    /// The program sent data to an output device.
+    Output {
+        /// Identifier of the target device.
+        device: u16,
+
+        /// The data sent.
+        data: i32,
+    },
 }
 
 /// Trait for consuming events.

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,72 @@
+//! Event handling.
+//!
+//! This library exposes an event-based interface for reacting
+//! to the state changes of the emulator in real-time. [EventListeners](EventListener)
+//! can be registered on the [Emulator](crate::emulator::Emulator) with the
+//! [add_listener](crate::emulator::Emulator::add_listener) method.
+//!
+//! A blanket implementation of [EventListener] for all `Fn(&Event)` is provided.
+
+use crate::instruction::Register;
+
+/// Represents an event that occurred while executing a program.
+pub enum Event {
+    /// The program triggered a supervisor call.
+    SupervisorCall {
+        /// The code of the supervisor call.
+        code: u16,
+    },
+
+    /// The program modified a memory location.
+    MemoryChange {
+        /// The address of the changed memory location.
+        address: u16,
+
+        /// New value of the changed memory location.
+        data: i32,
+    },
+
+    /// The program modified a register.
+    RegisterChange {
+        /// The register which was modified.
+        register: Register,
+
+        /// The new value of the register.
+        data: i32,
+    },
+}
+
+/// Trait for consuming events.
+pub trait EventListener {
+    /// Called whenever a new event has been created.
+    fn event(&mut self, event: &Event);
+}
+
+impl<F> EventListener for F where F: Fn(&Event) {
+    fn event(&mut self, event: &Event) {
+        self(event)
+    }
+}
+
+pub(crate) struct EventDispatcher {
+    listeners: Vec<Box<dyn EventListener>>,
+}
+
+impl EventDispatcher {
+    pub fn new() -> EventDispatcher {
+        EventDispatcher {
+            listeners: Vec::new(),
+        }
+    }
+
+    pub fn add_listener<L: EventListener + 'static>(&mut self, listener: L) {
+        self.listeners.push(Box::new(listener) as Box<dyn EventListener>)
+    }
+
+    pub fn dispatch(&mut self, event: Event) {
+        for listener in &mut self.listeners {
+            listener.event(&event);
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ pub mod bytecode;
 pub mod symbolic;
 pub mod compiler;
 pub mod error;
+pub mod event;
 
 //pub use emulator::{Memory, Emulator};
 //pub use program::Program;


### PR DESCRIPTION
The need to detect whenever a memory location changed value led me to implementing an event system. As of now, the emulator emits three kinds of events: `MemoryChange`, `RegisterChange` and `SupervisorCall`.

## Related PRs
- ttk91-wasm: [Implement an interface for the event system (#3)](https://github.com/dogamak/ttk91-wasm/pull/3)
- ttk91-web: [Implement an event system (#3)](https://github.com/dogamak/ttk91-web/pull/3)